### PR TITLE
Add default displaymode, like in README

### DIFF
--- a/MMM-rainfc.js
+++ b/MMM-rainfc.js
@@ -18,6 +18,7 @@ Module.register("MMM-rainfc",{
 		css: "MMM-rainfc.css",
 		refreshInterval: 1000 * 60 * 15, //refresh every 15 minutes
 		autohide: false,
+		displaymode: "smooth"
 	},
 
 	// Define required scripts.


### PR DESCRIPTION
After updating my mirror wouldn't start.
Found an issue from rainfc.

This PR fixed the underlying issue.

It might be nice to update the module to not make the mirror stop working at all if a configuration issue arises after updating.